### PR TITLE
商品一覧機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,8 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
 
   def index
-    # @items = Item.all
-    # 後で実装する「商品一覧表示機能」でブランチを作成した際に、差分としてプルリクエストに反映されなくなってしまうため
+    @items = Item.all.order("created_at DESC")
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,37 +126,37 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+      <% @items.each do |item| %>
+        <li class='list'>
+          <%= link_to "#" do %>
+            <div class = 'item-img-content'>
+            <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
+              <%# 商品が売れていればsold outを表示しましょう %>
+              <div class='sold-out'>
+                <span>Sold Out!!</span>
+              </div>
+              <%# //商品が売れていればsold outを表示しましょう %>
+
           </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              <%= item.title %>
+            </h3>
+            <div class='item-price'>
+              <span><%= item.price %>円<br><%= '配送料負担' %></span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+          <% end %>
+        </li>
+      <% end %>
 
       <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      <% if @items.empty? %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -174,8 +174,9 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
+      <%end%>
       <%# /商品がない場合のダミー %>
+
     </ul>
   </div>
   <%# /商品一覧 %>


### PR DESCRIPTION
# WHAT
1. コントローラー　indexアクションの設定
1. ビューファイルの変更

# WHY
1. Itemモデルの呼び出させるため
1. 一覧を表示させるため

# 機能のスクショ

- 画像が表示されており、画像がリンク切れなどになっていないこと
https://gyazo.com/da999e78ace1d875e880c9148b8d29ee

- 出品した商品の一覧表示ができていること
- 上から、出品された日時が新しい順に表示されること
- 「画像/価格/商品名」の3つの情報について表示できていること
https://gyazo.com/d3f08cbadb728862277ef9f74de094c8

- ログアウト状態のユーザーでも、商品一覧表示ページを見ることができること
https://gyazo.com/83a27b0b425d07973f20eafc41b1b9df

- 売却済みの商品は、画像上に「sold out」の文字が表示されるようになっていること
※購入機能実装後に実装します

以上、ご確認のほど、よろしくお願い致します。