### PR TITLE
商品詳細表示機能の実装

### DIFF
--- a/app/assets/stylesheets/items/show.css
+++ b/app/assets/stylesheets/items/show.css
@@ -62,6 +62,7 @@
 
 .or-text {
   font-size: 20px;
+  margin: 20px 0px; /* デフォルトから追加 */
 }
 
 .item-destroy {

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: [:index]
+  before_action :authenticate_user!, except: [:index, :show]
 
   def index
     @items = Item.all.order("created_at DESC")
@@ -16,6 +16,10 @@ class ItemsController < ApplicationController
     else
       render :new
     end
+  end
+
+  def show
+    @item = Item.find(params[:id])
   end
 
   private

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -4,6 +4,11 @@ class Item < ApplicationRecord
 
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :category
+  belongs_to :condition
+  belongs_to :shipping_from
+  belongs_to :shipping_fee
+  belongs_to :estimated_shipping
+
 
   with_options presence: true do
     validates :image

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,7 +128,7 @@
 
       <% @items.each do |item| %>
         <li class='list'>
-          <%= link_to "#" do %>
+          <%= link_to item_path(item) do %>
             <div class = 'item-img-content'>
             <%= image_tag item.image, class: "item-img" %>
 
@@ -144,7 +144,7 @@
               <%= item.title %>
             </h3>
             <div class='item-price'>
-              <span><%= item.price %>円<br><%= '配送料負担' %></span>
+              <span><%= item.price %>円<br><%= item.shipping_fee.name %></span>
               <div class='star-btn'>
                 <%= image_tag "star.png", class:"star-icon" %>
                 <span class='star-count'>0</span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,66 +4,60 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
-    </h2>
+      <%= @item.title %>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class='sold-out'>
-        <span>Sold Out!!</span>
+        <%# 一旦コメントアウト <span>Sold Out!!</span> %>
       </div>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= "¥ #{@item.price}" %>
       </span>
       <span class="item-postage">
-        <%= '配送料負担' %>
+        <%= @item.shipping_fee.name %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% if user_signed_in? && current_user == @item.user %>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <% elsif user_signed_in? %>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%> 
+    <% end %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_fee.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.shipping_from.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.estimated_shipping.name %></td>
         </tr>
       </tbody>
     </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
 
-  resources :items, only:[:index, :new, :create]
+  resources :items, only:[:index, :new, :create, :show]
   
 end
 


### PR DESCRIPTION
# WHAT
1. showアクションの設定
1. view内　パスの設定
1. activeHashのアソシエーション設定
**要確認お願いします**
1. CSSでマージンの調整（or-text）

# WHY
1. 商品詳細ページを作成するため
1. 商品詳細ページ遷移させるため
1. 前回実装した商品一覧表示機能で記述が抜けていたため
**要確認お願いします**
1. 配布されていたCSSだとボックスとの間が窮屈にだったため

# スクショ

* ログイン状態の出品者のみ、「編集・削除ボタン」が表示されること
https://gyazo.com/67972548254de72914557f915717959f

***
* ログイン状態の出品者以外のユーザーのみ、「購入画面に進むボタン」が表示されること
https://gyazo.com/09c9e3e8589931b178aa0b8d8eba1e41

***
* ログアウト状態のユーザーでも、商品詳細表示ページを閲覧できること
* ログアウト状態のユーザーには、「編集・削除・購入画面に進むボタン」が表示されないこと
https://gyazo.com/ed1658a4d1cac290b4ae71a90334bf9b
***
* 商品出品時に登録した情報が見られるようになっていること
* 画像が表示されており、画像がリンク切れなどになっていないこと
https://gyazo.com/8786e2087457e507cc8edacb715eed24

***
* 売却済みの商品は、画像上に「sold out」の文字が表示されるようになっていること
* ログイン状態の出品者でも、売却済みの商品に対しては「編集・削除ボタン」が表示されないこと
※商品購入機能実装後に実装する
